### PR TITLE
Docker build via official Rust image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+target/
+.git*
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM rust:buster as builder
+
+COPY . /usr/src/
+
+WORKDIR /usr/src
+
+RUN ["cargo", "build", "-r"]
+
+FROM rust:buster
+
+LABEL org.opencontainers.image.authors="kayvan.sylvan@gmail.com"
+
+COPY --from=builder /usr/src/target/release/agg /usr/local/bin/
+
+ENTRYPOINT [ "/usr/local/bin/agg" ]
+

--- a/README.md
+++ b/README.md
@@ -29,6 +29,28 @@ cargo build -r
 This produces an executable file at `target/release/agg`. There are no other
 build artifacts so you can copy the binary to a directory in your `$PATH`.
 
+## Building via Docker (no Rust install needed)
+
+As an alternative to building with Rust locally, you can install Rancher
+Desktop or another docker-compatible tool. In the examples below,
+we are using `nerdctl` as the docker compatible tool, and this will
+also work with Docker Desktop, using the `docker` command.
+
+```sh
+nerdctl build -t agg .
+```
+
+Then you can do this:
+
+```sh
+mkdir -p ~/TMP 
+cp demo.cast ~/TMP
+nerdctl run --rm -it -v ~/TMP:/casts agg /casts/demo.cast /casts/demo.gif
+```
+
+This will create the `.gif` file in the `~/TMP` directory. If you don't want to build
+the image, you can always use the image here: <https://hub.docker.com/r/kayvan/agg>.
+
 ## Usage
 
 Basic usage:
@@ -49,7 +71,7 @@ agg --theme monokai --font-size 20 --speed 2 demo.cast demo.gif
 
 Run `agg -h` to see all available options. Current options are:
 
-```
+```text
     --cols <COLS>
         Override terminal width (number of columns)
 
@@ -126,9 +148,10 @@ To verify agg picks up your font run it with `-v` (verbose) flag:
 ```bash
 agg -v --font-family "Source Code Pro,Fira Code" demo.cast demo.gif
 ```
+
 It should print something similar to:
 
-```
+```text
 [INFO agg] selected font families: ["Source Code Pro", "Fira Code", "DejaVu Sans", "Noto Emoji"]
 ```
 
@@ -138,7 +161,7 @@ earlier), as well as Noto Emoji (see section below).
 Here's how to use [Nerd Fonts](https://www.nerdfonts.com/) with agg:
 
 1. Download one of the patched font sets from
-   https://github.com/ryanoasis/nerd-fonts/releases/latest , e.g. JetBrainsMono.zip
+   <https://github.com/ryanoasis/nerd-fonts/releases/latest> , e.g. JetBrainsMono.zip
 2. Unzip them into `~/.local/share/fonts` (on Linux) or install with system font
    manager (macOS, Windows)
 3. Specify font family like this:
@@ -179,7 +202,7 @@ A custom, ad-hoc theme can be used with `--theme` option by passing a series of
 comma-separated hex triplets defining terminal background color, default text
 color and a color palette:
 
-```
+```text
 --theme bbbbbb,ffffff,000000,111111,222222,333333,444444,555555,666666,777777
 ```
 
@@ -190,7 +213,7 @@ palette](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors).
 Additional bright color variants can be specified by adding 8 more hex triplets
 at the end. For example, the equivalent of the built-in Monokai theme is:
 
-```
+```text
 --theme 272822,f8f8f2,272822,f92672,a6e22e,f4bf75,66d9ef,ae81ff,a1efe4,f8f8f2,75715e,f92672,a6e22e,f4bf75,66d9ef,ae81ff,a1efe4,f9f8f5
 ```
 


### PR DESCRIPTION
# Docker build using the official Rust image

This can make `agg` available in an easier way to lots of people, even if they install no Rust toolchain on their machine. They just need to have Rancher Desktop, or Docker Desktop, or Podman equivalent running on their local machine.

For example, running my auto-built docker image (`kayvan/agg`) like this, with Rancher Desktop installed:

```sh
mkdir ~/TMP
cp demo.cast ~/TMP
docker run --rm -it -v ~/TMP:/data kayvan/agg /data/demo.cast /data/demo.gif
```

Produces this output:

```
docker.io/kayvan/agg:latest:                                                      resolved       |++++++++++++++++++++++++++++++++++++++| 
manifest-sha256:9c39b20f22be6c7de229b47bfd273333e684946af08dcd3aa994174d27132ed7: done           |++++++++++++++++++++++++++++++++++++++| 
config-sha256:db02b598c188205ca3aa58baec1c83e92727b6b7a7bd13d785b1512fac60cc06:   done           |++++++++++++++++++++++++++++++++++++++| 
layer-sha256:4e2befb7f5d18aa27b3619ddf1b93607e62ca82d0c627557537c149893346d86:    done           |++++++++++++++++++++++++++++++++++++++| 
layer-sha256:1239d419cad84685c9974776908892674967b4ccb92ace613fc934d14591226d:    done           |++++++++++++++++++++++++++++++++++++++| 
layer-sha256:591fe17e35ddac86d63495a7708b07af369e0d67d8742880f1e73cf1a205e028:    done           |++++++++++++++++++++++++++++++++++++++| 
layer-sha256:b9cba6e3073a1f2eac2d50c107bba6dbb76de0325854a3a0e7c6f52ae8fc5521:    done           |++++++++++++++++++++++++++++++++++++++| 
layer-sha256:fa5957c9ac69e09358f52b9555a1c78be37617f680ac9f6e1168dad047763956:    done           |++++++++++++++++++++++++++++++++++++++| 
layer-sha256:3e37868ebf669334a2dbdb206ac7b84d8f8d184a40dfb8c9bc501b29cda12548:    done           |++++++++++++++++++++++++++++++++++++++| 
layer-sha256:792af667f62688dbef1f3ffeeca2daa6d448a62b6cacd604f1c4fc043d6cc2a6:    done           |++++++++++++++++++++++++++++++++++++++| 
elapsed: 90.6s                                                                    total:  472.4  (5.2 MiB/s)                                       
212 / 212 [===================================================================================================================================================================================================================================================================================] 100.00 % 6.05/s
``` 
