### PR TITLE
Improve docs around passing asciinema URL as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ agg demo.cast demo.gif
 The above command renders a GIF file with default theme (dracula), font size
 14px.
 
+You can also provide an asciinema.org URL as the first argument:
+
+```bash
+agg https://asciinema.org/a/569727 starwars.gif
+```
+
 Additional options are available for customization. For example, the following
 command selects Monokai theme, larger font size, 2x playback speed:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ impl clap::builder::TypedValueParser for ThemeValueParser {
 #[clap(author, version, about, long_about = None)]
 struct Cli {
     /// asciicast path/filename or URL
-    input_filename: String,
+    input_filename_or_url: String,
 
     /// GIF path/filename
     output_filename: String,
@@ -180,7 +180,7 @@ fn main() -> Result<()> {
         show_progress_bar: true,
     };
 
-    let input = BufReader::new(reader(&cli.input_filename)?);
+    let input = BufReader::new(reader(&cli.input_filename_or_url)?);
     let mut output = File::create(&cli.output_filename)?;
     agg::run(input, &mut output, config)
 }


### PR DESCRIPTION
The addition to the README is solid, but I'm not sure if the input variable rename has the intended effect. Happy to remove that or make changes if there's a better way to document this feature!