### PR TITLE
Fix FromAsCasing warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:buster as builder
+FROM rust:buster AS builder
 
 COPY . /usr/src/
 


### PR DESCRIPTION
While building the image following the `README.md`, we see this warning at the end of the build.

```bash
 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
```
![screenshot](https://github.com/user-attachments/assets/1ec6049d-be1c-4163-bf83-afec1c7b9e8d)

This happens because of `FromAsCasing` build check, as it shows in the log. More details on `FromAsCasing` build check can be found in this: [FromAsCasing | Docker Docs](https://docs.docker.com/reference/build-checks/from-as-casing/) doc.

This MR fixes the `FromAsCasing` warning by changing the case of `as` to uppercase.