### PR TITLE
Allow user to configure fallback fonts

### DIFF
--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -1,4 +1,4 @@
-pub fn init(font_dirs: &[String], font_family: &str) -> Option<(fontdb::Database, Vec<String>)> {
+pub fn init(font_dirs: &[String], font_family: &str, fallback_fonts: &str) -> Option<(fontdb::Database, Vec<String>)> {
     let mut font_db = fontdb::Database::new();
     font_db.load_system_fonts();
 
@@ -15,7 +15,7 @@ pub fn init(font_dirs: &[String], font_family: &str) -> Option<(fontdb::Database
     if families.is_empty() {
         None
     } else {
-        for name in ["DejaVu Sans", "Noto Emoji"] {
+        for name in fallback_fonts.split(',').map(str::trim) {
             if let Some(name) = find_font_family(&font_db, name) {
                 if !families.contains(&name) {
                     families.push(name);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ use crate::asciicast::Asciicast;
 
 pub const DEFAULT_FONT_FAMILY: &str =
     "JetBrains Mono,Fira Code,SF Mono,Menlo,Consolas,DejaVu Sans Mono,Liberation Mono";
+pub const DEFAULT_FALLBACK_FONTS: &str = "Noto Sans,DejaVu Sans,Noto Emoji";
 pub const DEFAULT_FONT_SIZE: usize = 16;
 pub const DEFAULT_FPS_CAP: u8 = 30;
 pub const DEFAULT_LAST_FRAME_DURATION: f64 = 3.0;
@@ -29,6 +30,7 @@ pub struct Config {
     pub cols: Option<usize>,
     pub font_dirs: Vec<String>,
     pub font_family: String,
+    pub fallback_fonts: String,
     pub font_size: usize,
     pub fps_cap: u8,
     pub idle_time_limit: Option<f64>,
@@ -48,6 +50,7 @@ impl Default for Config {
             cols: None,
             font_dirs: vec![],
             font_family: String::from(DEFAULT_FONT_FAMILY),
+            fallback_fonts: String::from(DEFAULT_FALLBACK_FONTS),
             font_size: DEFAULT_FONT_SIZE,
             fps_cap: DEFAULT_FPS_CAP,
             idle_time_limit: None,
@@ -160,7 +163,7 @@ pub fn run<I: BufRead, O: Write + Send>(input: I, output: O, config: Config) -> 
 
     info!("terminal size: {}x{}", terminal_size.0, terminal_size.1);
 
-    let (font_db, font_families) = fonts::init(&config.font_dirs, &config.font_family)
+    let (font_db, font_families) = fonts::init(&config.font_dirs, &config.font_family, &config.fallback_fonts)
         .ok_or_else(|| anyhow!("no faces matching font families {}", config.font_family))?;
 
     info!("selected font families: {:?}", font_families);

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,10 @@ struct Cli {
     #[clap(long, default_value_t = String::from(agg::DEFAULT_FONT_FAMILY))]
     font_family: String,
 
+    /// Specify fallback font families
+    #[clap(long, default_value_t = String::from(agg::DEFAULT_FALLBACK_FONTS))]
+    fallback_fonts: String,
+
     /// Specify font size (in pixels)
     #[clap(long, default_value_t = agg::DEFAULT_FONT_SIZE)]
     font_size: usize,
@@ -176,6 +180,7 @@ fn main() -> Result<()> {
         cols: cli.cols,
         font_dirs: cli.font_dir,
         font_family: cli.font_family,
+        fallback_fonts: cli.fallback_fonts,
         font_size: cli.font_size,
         fps_cap: cli.fps_cap,
         idle_time_limit: cli.idle_time_limit,


### PR DESCRIPTION
Hey there! Thank you for making this project! I'm an extensive user of asciinema as well. Lately I've been trying to get rid of [vhs](https://github.com/charmbracelet/vhs) and have been trying to integrate agg into my project.

I am using it to [generate GIFs in CI](https://cfoust.github.io/cy/animations.html) and realized that some glyphs were not rendering correctly. The primary cause was that agg's `--font-family` did not work the way I expected: agg searches for missing glyphs in a few hardcoded fonts, not in the next entry in the `--font-family` list. If the glyph still does not exist in one of the hardcoded fallback fonts, agg just renders a question mark symbol.

This (entirely vibe coded) PR just makes that fallback list configurable.

Personally I think this behavior is less than ideal. Rather than having two sets of fonts, one of which is only used in the case of a missing glyph, I'd rather just give agg a priority list of fonts and query each font in order until a glyph is found.

Fixes #105